### PR TITLE
Update ChatSpatial entry with paper reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Following subsection will be subsequently divided by argument while collecting t
 ### Spatial Transcriptomics Methods & Tools
 |Year|Title|Language|Description|Reference|
 |:-:|:--|:-:|:--|:--|
-|2025|[ChatSpatial](https://github.com/cafferychen777/ChatSpatial)|Python|MCP server enabling spatial transcriptomics analysis via natural language. Integrates 60+ methods for spatial domains, deconvolution, cell communication, trajectory analysis across Visium, Xenium, MERFISH.|[PyPI](https://pypi.org/project/chatspatial/) / [Docs](https://cafferychen777.github.io/ChatSpatial/)|
+|2026|[ChatSpatial](https://github.com/cafferychen777/ChatSpatial)|Python|MCP server enabling spatial transcriptomics analysis via natural language. Integrates 60+ methods for spatial domains, deconvolution, cell communication, trajectory analysis across Visium, Xenium, MERFISH.|[Yang et al. 2026](https://doi.org/10.64898/2026.02.26.708361) / [PyPI](https://pypi.org/project/chatspatial/) / [Docs](https://cafferyang.com/ChatSpatial/)|
 |2021|[Giotto](http://spatialgiotto.rc.fas.harvard.edu/)|R|Toolbox for integrative analysis and visualization of spatial expression data|[Dries et al. 2021](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-021-02286-2)|
 |2025|[FlashDeconv](https://github.com/cafferychen777/flashdeconv)|Python|High-performance spatial deconvolution using randomized sketching. Processes 1M spots in ~3 min with linear O(N) scaling.|[Yang et al. 2025](https://doi.org/10.64898/2025.12.22.696108)|
 


### PR DESCRIPTION
Update the ChatSpatial entry to include the published paper reference:

**Yang, C., Zhang, X., & Chen, J. (2026).** ChatSpatial: Schema-Enforced Agentic Orchestration for Reproducible and Cross-Platform Spatial Transcriptomics. *bioRxiv*. https://doi.org/10.64898/2026.02.26.708361

Changes:
- Added paper citation (Yang et al. 2026) with DOI link
- Updated year from 2025 to 2026 (publication year)
- Updated documentation URL